### PR TITLE
fix: accept newer versions of API as long as major version is the same

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -6,8 +6,10 @@
  * See LICENSE for terms
  */
 
+const semverSatisfies = require('semver/functions/satisfies');
+
 // Constants /////////////////////////////////////////////////////////////////
-const API_VERSION = "1.0.0";
+const API_VERSION = "^1.0.0";
 
 // Utilities /////////////////////////////////////////////////////////////////
 
@@ -367,9 +369,9 @@ function createClient(workspaceId) {
   }
 
   return _request(`/api`, "GET").then(apiInfo => {
-    if (apiInfo.version !== API_VERSION) {
+    if (!semverSatisfies(apiInfo.version, API_VERSION)) {
       throw _panic(
-        `Incompatible API version (expected ${API_VERSION}, got ${apiInfo.version})`
+        `Incompatible API version (must satisfy ${API_VERSION}, got ${apiInfo.version})`
       );
     } else {
       return new API(workspaceId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,13 @@
 {
   "name": "@modelon/impact-client-js",
-  "version": "1.1.7",
-  "lockfileVersion": 1
+  "version": "1.1.8",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "semver": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelon/impact-client-js",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "Modelon Impact Client for Javascript",
   "main": "index.js",
   "scripts": {
@@ -16,5 +16,8 @@
   "bugs": {
     "url": "https://github.com/modelon-community/impact-client-js/issues"
   },
-  "homepage": "https://github.com/modelon-community/impact-client-js#readme"
+  "homepage": "https://github.com/modelon-community/impact-client-js#readme",
+  "dependencies": {
+    "semver": "^7.3.2"
+  }
 }


### PR DESCRIPTION
This PR changes the version check of the API such that newer minor and patch versions always are considered ok. Only a change in major version is considered breaking.