### PR TITLE
Bugfix/relative paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelon/impact-client-js",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelon/impact-client-js",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Modelon Impact Client for Javascript",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -509,8 +509,10 @@ API.prototype.getCurrentModel = function() {
  *
  * @param {string} workspaceId - The id of the workspace
  * @param {number} bumpInterval - Bumps the expiration of the clone with the interval given in seconds
+ * @param {string} impactUrl - URL to the Impact instance to use. Required if Impact is not running at the root, i.e. if it is located on some path like http://example.com/some/path
  * @returns {Promise<object>} An object containing the workspaceId of the cloned workspace and the intervalId of the bumper
  * @throws {Error} If no workspace id is present
+ * @throws {TypeError} If impactURL is not a valid URL
  */
 export function cloneWorkspace(workspaceId, bumpInterval, impactUrl='') {
     let params = _getParams(impactUrl);
@@ -541,8 +543,10 @@ export function cloneWorkspace(workspaceId, bumpInterval, impactUrl='') {
  * Creates a client object
  *
  * @param {string} workspaceId - The id of the workspace
+ * @param {string} impactUrl - URL to the Impact instance to use. Required if Impact is not running at the root, i.e. if it is located on some path like http://example.com/some/path
  * @returns {Promise<API>} An API-object for the given workspace
  * @throws {Error} If no workspace id is present
+ * @throws {TypeError} If impactUrl is not a valid URL
  */
 export function createClient(workspaceId, impactUrl='') {
     let params = _getParams();


### PR DESCRIPTION
This appends the impact base uri to the requests, which is required when Impact is installed with a relative path. Since the webapp does not have access to the env variable, it takes the uri from the browsers location and uses everything up to the /workspaces part of the url. 

EDIT: I have changed it so that you set the impact url as a function argument instead of using the browser location. If impact is on a standard location, you don't have to set that variable.