### PR TITLE
Fix login to use impact url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelon/impact-client-js",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelon/impact-client-js",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Modelon Impact Client for Javascript",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,8 @@ const API_VERSION = "^1.8.0";
 // Utilities /////////////////////////////////////////////////////////////////
 
 function _panic(msg, data) {
-    alert(msg);
-    return new Error(data || msg);
+    const extraInfo = data ? `: ${JSON.stringify(data)}` : ''
+    return new Error(`${msg}${extraInfo}`);
 }
 
 function _getCustomizedWorkspaceId(impactUrl) {

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ const _responses = {
     500: "Unexpected error"
 };
 
-function _request(path, method, init=undefined) {
+function _request(path, method, init) {
     return fetch(path, {
         headers: {
             "Content-Type": "application/json",


### PR DESCRIPTION
This PR fixes issues related to login for web apps:
 * The login call did not take impactUrl into consideration resulting in incorrect requests specified
 * The login was triggered on if you had a specific cookie or not, did not take into considerations that it might not be valid anymore
 * The login was not triggered if the clone bump request would need it

How to test:
 * Checkout https://github.com/modelon-community/impact-webapp-example and this PR
 * Change the dependency for the impact-webapp so it uses source: `"@modelon/impact-client-js": "file:./../../impact-client-js"`
 * Build this project: `npm install`, `npm run build`
 * Build the webapp example project (remember to go into the `pressure-cycle` folder): `npm install`, `npm run build`
 * Start the webapp example: `npm run proxy` (Do not forget to set TARGET env if not running impact on localhost)
 * Open the impact running at TARGET and create a workspace 'test_web_app'
 * Go to localhost:3000?workspaceId=test_web_app
    - Observe that it will call login if needed
    - Test deleting cookies and see that login is called for next request which will then retry (during simulation or loading page)
    - TIPS: add `&bumpInterval=10000` to the URL to not have random clone bump calls happen while testing other requests