### PR TITLE
 fix npm publish

### DIFF
--- a/.github/workflows/publish-to-npm.yaml
+++ b/.github/workflows/publish-to-npm.yaml
@@ -11,6 +11,7 @@ jobs:
         with:
           node-version: 14
       - run: npm install
+      - run: npm run build
       - run: npm test
       # Pin JS-DevTools/npm-publish@v1 to it's SHA.
       - uses: JS-DevTools/npm-publish@0f451a94170d1699fd50710966d48fb26194d939

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelon/impact-client-js",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelon/impact-client-js",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Modelon Impact Client for Javascript",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Unfortunately version 1.6.4 is broken, the build output is not included in the package published to npm.

The goal of this PR is to amend this by actually running `npm run build` before publishing.