### PR TITLE
feat: update impact js client to utilize api gateway authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For non-browser scripting purposes the best alternative is to use [impact-client
 
 ### Authentication
 
-If your app is running inside the Modelon Impact JupyterHub environment you only need to provide an Impact API key to authenticate. If your app runs outside the JupyterHub environment it will also need to authenticate towards JupyterHub using a token.
+If your app is running inside the Modelon Impact JupyterHub environment you can either use an Impact API key or use the authentication cookie (via `Client.fromImpactSession`) to authenticate. If your app runs outside the JupyterHub environment you will always have to use the Impact API key for authentication. The API-key can be generated from the Server Management page.
 
 #### Obtaining and setting the Impact API key
 
@@ -63,7 +63,6 @@ Create a `.env` file in the root of your project with the following content:
 
 ```bash
 MODELON_IMPACT_CLIENT_API_KEY=<your impact API key>
-JUPYTERHUB_API_TOKEN=<your JupyterHub API token>
 MODELON_IMPACT_SERVER=<Modelon Impact server address>
 ```
 
@@ -84,7 +83,6 @@ dotenv.config();
 
 const client = Client.fromImpactApiKey({
   impactApiKey: process.env.MODELON_IMPACT_CLIENT_API_KEY,
-  jupyterHubToken: process.env.JUPYTERHUB_API_TOKEN,
   serverAddress: process.env.MODELON_IMPACT_SERVER,
 });
 

--- a/examples/modelDescription.mjs
+++ b/examples/modelDescription.mjs
@@ -1,4 +1,4 @@
-// This script examplifies how to get model description units and variables.
+// This script exemplifies how to get model description units and variables.
 //
 // Make sure to have installed dependencies and have the required environment variables
 // available, as described in the Quick start example:
@@ -20,7 +20,6 @@ dotenv.config({ path: '../.env' })
 
 const client = Client.fromImpactApiKey({
     impactApiKey: process.env.MODELON_IMPACT_CLIENT_API_KEY,
-    jupyterHubToken: process.env.JUPYTERHUB_API_TOKEN,
     serverAddress: process.env.MODELON_IMPACT_SERVER,
 })
 

--- a/examples/multi.mjs
+++ b/examples/multi.mjs
@@ -1,4 +1,4 @@
-// This script examplifies how to use the Range operator to create
+// This script exemplifies how to use the Range operator to create
 // a multi-execution experiment.
 //
 // Make sure to have installed dependencies and have the required environment variables
@@ -22,7 +22,6 @@ dotenv.config({ path: '../.env' })
 
 const client = Client.fromImpactApiKey({
     impactApiKey: process.env.MODELON_IMPACT_CLIENT_API_KEY,
-    jupyterHubToken: process.env.JUPYTERHUB_API_TOKEN,
     serverAddress: process.env.MODELON_IMPACT_SERVER,
 })
 

--- a/src/api-error.ts
+++ b/src/api-error.ts
@@ -3,7 +3,6 @@ export const InvalidApiKey = 11034
 const BASE = 100000
 export const UnknownApiError = BASE
 export const MissingAccessTokenCookie = BASE + 1
-export const MissingJupyterHubToken = BASE + 2
 export const ServerNotStarted = BASE + 3
 export const JhTokenError = BASE + 4
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -117,6 +117,9 @@ class Api {
         jupyterHubUserPath?: string
         serverAddress?: string
     }) {
+        if (isNode()) {
+            throw new Error("Impact session can only be used from browser.")
+        }
         return new Api({
             jupyterHubUserPath,
             serverAddress,
@@ -160,7 +163,7 @@ class Api {
         } else {
             if (this.impactApiKey && !this.apiKeySet()) {
                 const headers: Record<string, string> = {
-                    'impact-api-key': `Bearer ${this.impactApiKey}`,
+                    'impact-api-key': `${this.impactApiKey}`,
                 }
                 this.axiosConfig = { headers }
                 this.axios = Axios.create(this.axiosConfig)

--- a/src/api.ts
+++ b/src/api.ts
@@ -745,6 +745,11 @@ class Api {
                 .catch((e) => reject(toApiError(e)))
         })
 
+    setImpactApiKey = (apiKey: string) => {
+        this.impactApiKey = apiKey;
+        this.configureAxios();
+    }
+
     delete = (path: string) =>
         new Promise((resolve, reject) => {
             this.ensureImpactAuth()

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,11 +1,10 @@
 import Axios, { AxiosError, AxiosInstance } from 'axios'
 import ApiError, {
     JhTokenError,
-    MissingAccessTokenCookie,
     ServerNotStarted,
     UnknownApiError,
 } from './api-error'
-import { Cookie, CookieJar, MemoryCookieStore } from 'tough-cookie'
+import { CookieJar, MemoryCookieStore } from 'tough-cookie'
 import Project from './project'
 import Workspace from './workspace'
 import {
@@ -45,18 +44,6 @@ const getCookieValue = (key: string) => {
     return parts.length === 2 ? parts.pop()?.split(';').shift() : undefined
 }
 
-const getValueFromJarCookies = (key: string, cookies: Cookie[]): string => {
-    const cookie = cookies.find((c) => c.key === key)
-
-    if (!cookie) {
-        throw new ApiError({
-            errorCode: MissingAccessTokenCookie,
-            message: 'Access token cookie not found',
-        })
-    }
-    return cookie.value
-}
-
 const toApiError = (e: AxiosError | Error) => {
     if (e instanceof AxiosError) {
         return new ApiError({
@@ -73,7 +60,6 @@ class Api {
     private axiosConfig!: AxiosConfig
     private baseUrl: string
     private impactApiKey?: string
-    private impactSession?: string
     private jhUserPath: string | undefined
 
     private configureAxios() {

--- a/src/api.ts
+++ b/src/api.ts
@@ -142,7 +142,7 @@ class Api {
     private apiKeySet = () =>
         !!this.axiosConfig.headers['impact-api-key'] 
 
-    private hasImpactSession = () => !getCookieValue("impact-session");
+    private hasImpactSession = () => !!getCookieValue("impact-session");
 
     private userPathFromUrl(url: string) {
         const regex = /\/user\/([^/]+)\//
@@ -708,11 +708,6 @@ class Api {
                 })
                 .catch((e) => reject(toApiError(e)))
         })
-
-    setImpactSession = (session: string) => {
-        this.impactSession = session
-        this.configureAxios()
-    }
 
     getModelExecutableInfo = ({
         fmuId,

--- a/src/api.ts
+++ b/src/api.ts
@@ -183,7 +183,6 @@ class Api {
     }
 
     private ensureJhUserPath = async () => {
-        // TODO: Requires api-key to be present at the moment
         if (this.jhUserPath) {
             return
         }

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,6 +1,6 @@
 import Axios, { AxiosError, AxiosInstance } from 'axios'
 import ApiError, {
-    JhTokenError,
+    InvalidApiKey,
     ServerNotStarted,
     UnknownApiError,
 } from './api-error'
@@ -213,7 +213,7 @@ class Api {
         } catch (e) {
             if (e instanceof AxiosError) {
                 throw new ApiError({
-                    errorCode: JhTokenError,
+                    errorCode: InvalidApiKey,
                     httpCode: e.response?.status,
                     message:
                         'Failed to authorize with JupyterHub, invalid api key?',

--- a/src/client.ts
+++ b/src/client.ts
@@ -109,6 +109,8 @@ class Client {
         return await this.api.deleteWorkspace(workspaceId)
     }
 
+    setImpactApiKey = (apiKey: string) =>  this.api.setImpactApiKey(apiKey);
+
     delete = (path: string) => this.api.delete(path)
     get = (path: string, accept?: string) => this.api.get(path, accept)
     post = (path: string, body: unknown, accept?: string) =>

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,7 +14,6 @@ class Client {
      *
      * @static
      * @param {Object} options - The options for creating an instance.
-     * @param {string} options.impactApiKey - The Impact API key. Optional.
      * @param {string} [options.jupyterHubToken] - The Jupyter Hub token. Optional.
      * @param {string} [options.jupyterHubUserPath] - The Jupyter Hub user path, extract it
      *                 from the URL when using the Modelon Impact main UI. Optional.
@@ -25,7 +24,6 @@ class Client {
      * @example
      *          Client.fromImpactApiKey({
      *              impactApiKey: "tKQqbeEh6QEVPWe60LCu4nN5fJbkvGYsWM-hcLEH",
-     *              jupyterHubToken: "d4cff74746ddf3d3c78bc653c303717b",
      *              jupyterHubUserPath: "/user/username@company.com/",
      *              serverAddress: "https://impact.modelon.cloud",
      *          })
@@ -33,18 +31,15 @@ class Client {
      */
     static fromImpactApiKey({
         impactApiKey,
-        jupyterHubToken,
         jupyterHubUserPath,
         serverAddress,
     }: {
         impactApiKey?: string
-        jupyterHubToken?: string
         jupyterHubUserPath?: string
         serverAddress?: string
     }) {
         const api = Api.fromImpactApiKey({
             impactApiKey,
-            jupyterHubToken,
             jupyterHubUserPath,
             serverAddress,
         })
@@ -52,11 +47,10 @@ class Client {
     }
 
     /**
-     * Creates an instance from an Impact token.
+     * Creates an instance from an Impact Session Cookie.
      *
      * @static
      * @param {Object} options - The options for creating an instance.
-     * @param {string} options.impactToken - The Impact token.
      * @param {string} [options.jupyterHubToken] - The Jupyter Hub token. Optional.
      * @param {string} [options.jupyterHubUserPath] - The Jupyter Hub user path, extract it
      *                 from the URL when using the Modelon Impact main UI. Optional.
@@ -73,24 +67,20 @@ class Client {
      *              serverAddress: "https://impact.modelon.cloud",
      *          })
      */
-    static fromImpactToken({
-        impactToken,
-        jupyterHubToken,
+    static fromImpactSession({
         jupyterHubUserPath,
         serverAddress,
     }: {
-        impactToken: string
-        jupyterHubToken?: string
         jupyterHubUserPath?: string
         serverAddress?: string
     }) {
+        /*
         const api = Api.fromImpactToken({
-            impactToken,
-            jupyterHubToken,
             jupyterHubUserPath,
             serverAddress,
         })
         return new Client(api)
+        */
     }
 
     getWorkspaces = (): Promise<Workspace[]> => this.api.getWorkspaces()
@@ -124,7 +114,7 @@ class Client {
         return await this.api.deleteWorkspace(workspaceId)
     }
 
-    setImpactToken = (token: string) => this.api.setImpactToken(token)
+    setImpactToken = (token: string) => this.api.setImpactSession(token)
 
     delete = (path: string) => this.api.delete(path)
     get = (path: string, accept?: string) => this.api.get(path, accept)

--- a/src/client.ts
+++ b/src/client.ts
@@ -47,11 +47,10 @@ class Client {
     }
 
     /**
-     * Creates an instance from an Impact Session Cookie.
+     * Creates an instance assuming Impact Session Cookie exists.
      *
      * @static
      * @param {Object} options - The options for creating an instance.
-     * @param {string} [options.jupyterHubToken] - The Jupyter Hub token. Optional.
      * @param {string} [options.jupyterHubUserPath] - The Jupyter Hub user path, extract it
      *                 from the URL when using the Modelon Impact main UI. Optional.
      * @param {string} [options.serverAddress] - The server address. Optional.
@@ -61,8 +60,6 @@ class Client {
      *
      * @example
      *          Client.fromImpactToken({
-     *              impactToken: "eyBmYWtlUGF5bG9hZDogIkxvcmVtIGlwc3VtIGRvbG9yIHNpdCBhbWV0IiB9",
-     *              jupyterHubToken: "d4cff74746ddf3d3c78bc653c303717b",
      *              jupyterHubUserPath: "/user/username@company.com/",
      *              serverAddress: "https://impact.modelon.cloud",
      *          })
@@ -74,13 +71,11 @@ class Client {
         jupyterHubUserPath?: string
         serverAddress?: string
     }) {
-        /*
-        const api = Api.fromImpactToken({
+        const api = Api.fromImpactSession({
             jupyterHubUserPath,
             serverAddress,
         })
         return new Client(api)
-        */
     }
 
     getWorkspaces = (): Promise<Workspace[]> => this.api.getWorkspaces()
@@ -113,8 +108,6 @@ class Client {
     deleteWorkspace = async (workspaceId: WorkspaceId): Promise<void> => {
         return await this.api.deleteWorkspace(workspaceId)
     }
-
-    setImpactToken = (token: string) => this.api.setImpactSession(token)
 
     delete = (path: string) => this.api.delete(path)
     get = (path: string, accept?: string) => this.api.get(path, accept)

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,7 +14,6 @@ class Client {
      *
      * @static
      * @param {Object} options - The options for creating an instance.
-     * @param {string} [options.jupyterHubToken] - The Jupyter Hub token. Optional.
      * @param {string} [options.jupyterHubUserPath] - The Jupyter Hub user path, extract it
      *                 from the URL when using the Modelon Impact main UI. Optional.
      * @param {string} [options.serverAddress] - The server address. Optional.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import ApiError, {
     InvalidApiKey,
     JhTokenError,
     MissingAccessTokenCookie,
-    MissingJupyterHubToken,
     ServerNotStarted,
     UnknownApiError,
 } from './api-error'
@@ -58,7 +57,6 @@ export {
     InvalidApiKey,
     JhTokenError,
     MissingAccessTokenCookie,
-    MissingJupyterHubToken,
     Model,
     ModelDefinition,
     ModelDescription,

--- a/src/model-executable.ts
+++ b/src/model-executable.ts
@@ -1,6 +1,5 @@
 import Analysis from './analysis'
 import Api from './api'
-import DefaultExperiment from './default-experiment'
 import ExperimentDefinition from './experiment-definition'
 import ModelDescription from './model-description'
 import { XMLParser } from 'fast-xml-parser'

--- a/tests/integration/integration.test.ts
+++ b/tests/integration/integration.test.ts
@@ -4,7 +4,7 @@ import {
     ApiError,
     Client,
     ExperimentDefinition,
-    JhTokenError,
+    InvalidApiKey,
     Model,
 } from '../../dist'
 import { ModelicaExperimentDefinition, ModelicaModel } from '../../src/types'
@@ -64,7 +64,7 @@ test('Try to use invalid impact API key', async () => {
         // instanceof does not work for checking the type here, a ts-jest specific problem perhaps.
         // ApiError has errorCode.
         const error = e as ApiError;
-        expect(error.errorCode).toEqual(JhTokenError)
+        expect(error.errorCode).toEqual(InvalidApiKey)
         expect(error.httpCode).toEqual(400)
     }
 })

--- a/tests/integration/integration.test.ts
+++ b/tests/integration/integration.test.ts
@@ -4,7 +4,7 @@ import {
     ApiError,
     Client,
     ExperimentDefinition,
-    InvalidApiKey,
+    JhTokenError,
     Model,
 } from '../../dist'
 import { ModelicaExperimentDefinition, ModelicaModel } from '../../src/types'
@@ -17,7 +17,6 @@ const TwentySeconds = 20 * 1000
 
 const getClient = (options?: {
     impactApiKey?: string
-    impactSession?: string
 }) =>
     Client.fromImpactApiKey({
         impactApiKey:
@@ -65,7 +64,7 @@ test('Try to use invalid impact API key', async () => {
         // instanceof does not work for checking the type here, a ts-jest specific problem perhaps.
         // ApiError has errorCode.
         const error = e as ApiError;
-        expect(error.errorCode).toEqual(InvalidApiKey)
+        expect(error.errorCode).toEqual(JhTokenError)
         expect(error.httpCode).toEqual(400)
     }
 })

--- a/tests/integration/integration.test.ts
+++ b/tests/integration/integration.test.ts
@@ -5,9 +5,7 @@ import {
     Client,
     ExperimentDefinition,
     InvalidApiKey,
-    JhTokenError,
     Model,
-    Workspace,
 } from '../../dist'
 import { ModelicaExperimentDefinition, ModelicaModel } from '../../src/types'
 import { beforeEach, expect, test } from 'vitest'
@@ -19,15 +17,12 @@ const TwentySeconds = 20 * 1000
 
 const getClient = (options?: {
     impactApiKey?: string
-    jupyterHubToken?: string
+    impactSession?: string
 }) =>
     Client.fromImpactApiKey({
         impactApiKey:
             options?.impactApiKey ||
             (process.env.MODELON_IMPACT_CLIENT_API_KEY as string),
-        jupyterHubToken:
-            options?.jupyterHubToken ||
-            (process.env.JUPYTERHUB_API_TOKEN as string),
         serverAddress: process.env.MODELON_IMPACT_SERVER as string,
     })
 
@@ -75,26 +70,6 @@ test('Try to use invalid impact API key', () =>
                 if ('errorCode' in e) {
                     expect(e.errorCode).toEqual(InvalidApiKey)
                     expect(e.httpCode).toEqual(400)
-                    done()
-                }
-            })
-    }))
-
-test('Try to use invalid jupyter hub token', () =>
-    new Promise<void>((done) => {
-        const client = getClient({ jupyterHubToken: 'invalid-jh-token' })
-
-        client
-            .getWorkspace('non-existing-workspace')
-            .then(() => {
-                throw new Error('Test should have caught error')
-            })
-            .catch((e: ApiError) => {
-                // instanceof does not work for checking the type here, a ts-jest specific problem perhaps.
-                // ApiError has errorCode.
-                if ('errorCode' in e) {
-                    expect(e.errorCode).toEqual(JhTokenError)
-                    expect(e.httpCode).toEqual(403)
                     done()
                 }
             })

--- a/tests/integration/integration.test.ts
+++ b/tests/integration/integration.test.ts
@@ -55,25 +55,20 @@ const deleteTestWorkspace = async (client: Client) => {
     await Promise.all(deletePromises)
 }
 
-test('Try to use invalid impact API key', () =>
-    new Promise<void>((done) => {
-        const client = getClient({ impactApiKey: 'invalid-api-key' })
-
-        client
-            .getWorkspace('non-existing-workspace')
-            .then(() => {
-                throw new Error('Test should have caught error')
-            })
-            .catch((e: ApiError) => {
-                // instanceof does not work for checking the type here, a ts-jest specific problem perhaps.
-                // ApiError has errorCode.
-                if ('errorCode' in e) {
-                    expect(e.errorCode).toEqual(InvalidApiKey)
-                    expect(e.httpCode).toEqual(400)
-                    done()
-                }
-            })
-    }))
+test('Try to use invalid impact API key', async () => {
+    const client = getClient({ impactApiKey: 'invalid-api-key' })
+    
+    try {
+        await client.getWorkspace('non-existing-workspace')
+        throw new Error('Test should have caught error')
+    } catch (e) {
+        // instanceof does not work for checking the type here, a ts-jest specific problem perhaps.
+        // ApiError has errorCode.
+        const error = e as ApiError;
+        expect(error.errorCode).toEqual(InvalidApiKey)
+        expect(error.httpCode).toEqual(400)
+    }
+})
 
 test(
     'Setup and execute experiment from json experiment definition',

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -1,0 +1,8 @@
+import { Client } from '../../src'
+import { expect, test } from 'vitest'
+
+test('Try instantiating from impact session from node', () => {
+    const testFun = () => Client.fromImpactSession({});
+    expect(testFun).toThrow(Error);
+    expect(testFun).toThrow("Impact session can only be used from browser.");
+})

--- a/tests/unit/model-executable.test.ts
+++ b/tests/unit/model-executable.test.ts
@@ -21,7 +21,6 @@ test('Create and examine a ModelExecutable instance', async () => {
     // @ts-ignore
     const api = new Api({
         impactApiKey: 'mock-api-key',
-        jupyterHubToken: 'mock-jh-token',
     })
 
     const modelExecutable = await ModelExecutable.from({


### PR DESCRIPTION
What?
BREAKING CHANGE: This change drops support for token based authentication. The exchange happens in the api gateway on the modelon impact server. From now on you will need to use either authentication cookie in the browser OR impact-api-key to utilize the client via:
Client.fromImpactApiKey
or
Client.fromImpactSession

Why?
Following changes in coming authentication updates in Modelon Impact "API Gateway". JH-tokens are no longer needed to authenticate. Also, the exchange for the access token happens in the api gateway, meaning that we only need api-key or impact-session cookie to be present to authenticate.

How?
Removing:

Client.fromImpactToken()
Token exchange via /login

Also:
Updating how user-path is extracted
Adding check that impact-session cookie exists when using that as auth-method.

Testing?

Test suite has been updated to reflect changes
Dropped jhToken failure test

What is not in this MR
Missing:

A good way to test the cookie based authentication path
Convenience functions to re-establish impact session in the case of a logout.

Anything Else?
We should maybe wait to merge these changes until api-gateway work is done from cap-side.